### PR TITLE
Implement prompt creation on frontend

### DIFF
--- a/client/src/components/pages/Prompts.tsx
+++ b/client/src/components/pages/Prompts.tsx
@@ -1,5 +1,5 @@
 import { Head } from "../shared/Head";
-import CreateLyricsForm from "../shared/CreateLyricsForm";
+import CreatePromptForm from "../shared/CreatePromptForm";
 import PromptsList from "../shared/PromptsList";
 
 function Prompts() {
@@ -10,7 +10,7 @@ function Prompts() {
         <div className="card bg-base-200 shadow-xl">
           <div className="card-body">
             <h2 className="card-title text-primary">Create New Prompt</h2>
-            <CreateLyricsForm />
+            <CreatePromptForm />
           </div>
         </div>
 

--- a/client/src/components/shared/CreatePromptForm.tsx
+++ b/client/src/components/shared/CreatePromptForm.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { CREATE_PROMPT } from '../../graphql/mutations';
+import { GET_PROMPTS_BY_USER } from '../../graphql/queries';
+import { useAuthState } from '../../hooks/auth';
+
+function CreatePromptForm() {
+  const [genre, setGenre] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const authState = useAuthState();
+  const [createPrompt, { loading, error }] = useMutation(CREATE_PROMPT, {
+    refetchQueries: [
+      {
+        query: GET_PROMPTS_BY_USER,
+        variables: { userId: authState.currentUser?.uid }
+      }
+    ]
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!authState.currentUser?.uid) return;
+    try {
+      await createPrompt({
+        variables: {
+          userId: authState.currentUser.uid,
+          genre,
+          prompt
+        }
+      });
+      setGenre('');
+      setPrompt('');
+    } catch (err) {
+      console.error('Error creating prompt:', err);
+    }
+  };
+
+  if (!authState.currentUser) return null;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="text"
+        value={genre}
+        onChange={(e) => setGenre(e.target.value)}
+        placeholder="Genre"
+        className="w-full p-2 border rounded input input-bordered input-primary"
+      />
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Prompt"
+        className="w-full p-2 border rounded input input-bordered input-primary"
+        rows={4}
+      />
+      <button
+        type="submit"
+        disabled={loading || !genre.trim() || !prompt.trim()}
+        className="btn btn-outline btn-primary"
+      >
+        {loading ? 'Saving...' : 'Save Prompt'}
+      </button>
+      {error && <p className="text-red-500">Error: {error.message}</p>}
+    </form>
+  );
+}
+
+export default CreatePromptForm;

--- a/client/src/components/shared/PromptsList.tsx
+++ b/client/src/components/shared/PromptsList.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client';
-import { GET_PROMPTS } from '../../graphql/queries';
+import { GET_PROMPTS, GET_PROMPTS_BY_USER } from '../../graphql/queries';
+import { useAuthState } from '../../hooks/auth';
 
 interface Prompt {
   id: string;
@@ -8,17 +9,22 @@ interface Prompt {
 }
 
 interface PromptsData {
-  getPrompts: Prompt[];
+  getPrompts?: Prompt[];
+  getPromptsByUser?: Prompt[];
 }
 
 function PromptsList() {
-  const { loading, error, data } = useQuery<PromptsData>(GET_PROMPTS);
+  const authState = useAuthState();
+  const query = authState.currentUser ? GET_PROMPTS_BY_USER : GET_PROMPTS;
+  const variables = authState.currentUser ? { userId: authState.currentUser.uid } : undefined;
+  const { loading, error, data } = useQuery<PromptsData>(query, { variables });
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error: {error.message}</p>;
+  const prompts = data?.getPrompts ?? data?.getPromptsByUser ?? [];
   return (
     <div>
-      {data?.getPrompts.map((prompt) => (
+      {prompts.map((prompt) => (
         <div key={prompt.id}>{prompt.prompt}</div>
       ))}
     </div>

--- a/client/src/graphql/mutations.ts
+++ b/client/src/graphql/mutations.ts
@@ -14,3 +14,14 @@ export const CREATE_LYRICS = gql`
     }
   }
 `;
+
+export const CREATE_PROMPT = gql`
+  mutation CreatePrompt($userId: String!, $genre: String!, $prompt: String!) {
+    createPrompt(userId: $userId, genre: $genre, prompt: $prompt) {
+      id
+      genre
+      prompt
+      userId
+    }
+  }
+`;

--- a/client/src/graphql/queries.ts
+++ b/client/src/graphql/queries.ts
@@ -52,6 +52,16 @@ export const GET_PROMPT_BY_ID = gql`
   }
 `;
 
+export const GET_PROMPTS_BY_USER = gql`
+  query GetPromptsByUser($userId: ID!) {
+    getPromptsByUser(userId: $userId) {
+      id
+      genre
+      prompt
+    }
+  }
+`;
+
 
 
 


### PR DESCRIPTION
## Summary
- allow creating prompts from the UI
- list prompts for the current user when signed in
- add GraphQL operations for creating prompts and getting prompts by user

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68696ec71b40832eb03589afa0b022bc