### PR TITLE
Convert server tests and scripts to ES modules

### DIFF
--- a/client/.prettierrc.js
+++ b/client/.prettierrc.js
@@ -1,5 +1,5 @@
 // .prettierrc.js
-module.exports = {
+export default {
   printWidth: 80,
   singleQuote: true,
 };

--- a/client/src/components/domain/auth/AuthInitializer.tsx
+++ b/client/src/components/domain/auth/AuthInitializer.tsx
@@ -1,6 +1,6 @@
-import { useEffect, ReactNode } from "react";
-import { auth } from "../../../lib/firebase";
-import { onAuthStateChanged } from "firebase/auth";
+import { useEffect, ReactNode } from 'react';
+import { auth } from '../../../lib/firebase';
+import { onAuthStateChanged, type User } from 'firebase/auth';
 import { useDispatch } from 'react-redux';
 import { signIn, signOut } from '../../../store/slices/authSlice';
 import { serializeUser } from '../../../store/slices/authSlice';
@@ -21,19 +21,19 @@ export const AuthInitializer = ({ children }: { children: ReactNode }) => {
   const [upsertUser] = useMutation(UPSERT_USER);
 
   useEffect(() => {
-    const syncUser = async (user: any) => {
+    const syncUser = async (user: User | null) => {
       if (user) {
         try {
           await upsertUser({
             variables: {
               id: user.uid,
               email: user.email,
-              name: user.displayName
-            }
+              name: user.displayName,
+            },
           });
           dispatch(signIn({ user: serializeUser(user) }));
         } catch (error) {
-          console.error("Error syncing user:", error);
+          console.error('Error syncing user:', error);
         }
       } else {
         dispatch(signOut());

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
+export default {
   preset: "ts-jest",
   testEnvironment: "node",
   roots: ["<rootDir>/tests"],

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -1,34 +1,34 @@
-const { PrismaClient } = require('@prisma/client');
+import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 
 async function main() {
   // Create a mock user
   const user = await prisma.user.create({
     data: {
-      email: 'test@example.com',
-      name: 'Test User'
-    }
+      email: "test@example.com",
+      name: "Test User",
+    },
   });
 
   // Create some mock prompts
   await prisma.prompt.createMany({
     data: [
       {
-        genre: 'Metal',
-        prompt: 'Metal song, pop vocals, heavy drums, guitar riffs',
-        userId: user.id
+        genre: "Metal",
+        prompt: "Metal song, pop vocals, heavy drums, guitar riffs",
+        userId: user.id,
       },
       {
-        genre: 'Pop',
-        prompt: 'dark pop song, electronic drums, synth, pop vocals',
-        userId: user.id
+        genre: "Pop",
+        prompt: "dark pop song, electronic drums, synth, pop vocals",
+        userId: user.id,
       },
       {
-        genre: 'Metal',
-        prompt: 'Metalcore song about a girl who is a vampire',
-        userId: user.id
-      }
-    ]
+        genre: "Metal",
+        prompt: "Metalcore song about a girl who is a vampire",
+        userId: user.id,
+      },
+    ],
   });
 
   // Add some mock lyrics
@@ -36,8 +36,8 @@ async function main() {
     data: {
       userId: user.id,
       lyrics:
-        'Sample lyrics for a metal song...\nSecond line of lyrics\nThird line of lyrics'
-    }
+        "Sample lyrics for a metal song...\nSecond line of lyrics\nThird line of lyrics",
+    },
   });
 }
 

--- a/server/tests/resolvers.lyrics.test.ts
+++ b/server/tests/resolvers.lyrics.test.ts
@@ -16,8 +16,7 @@ jest.mock("@prisma/client", () => {
   return { PrismaClient: jest.fn(() => mPrisma) };
 });
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { resolvers } = require("../resolvers");
+import { resolvers } from "../resolvers";
 const prisma = new PrismaClient() as any;
 const mockContext = (userId?: string) => ({ req: {} as any, userId });
 

--- a/server/tests/resolvers.user.test.ts
+++ b/server/tests/resolvers.user.test.ts
@@ -9,8 +9,7 @@ jest.mock("@prisma/client", () => {
   return { PrismaClient: jest.fn(() => mPrisma) };
 });
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { resolvers } = require("../resolvers");
+import { resolvers } from "../resolvers";
 const prisma = new PrismaClient() as any;
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- use ESM syntax in Prisma seed script
- convert resolver tests to use `import` syntax
- migrate Jest configuration to ESM
- update Prettier config to ESM
- fix lint error in `AuthInitializer`

## Testing
- `npx eslint . --ext .js,.jsx,.ts,.tsx` in client
- `npm run -s --prefix server lint`
- `npm test --prefix server`
- `npm test --prefix client` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a46843f90832eae8565c66d6e6f45